### PR TITLE
updating before installing software-properties-common

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -2,6 +2,7 @@
 # vi: set ts=2 et sw=2 sts=2 :
 set -e
 
+sudo apt-get update
 sudo apt-get -y install --force-yes software-properties-common
 sudo add-apt-repository -y ppa:nginx/stable
 sudo apt-get update


### PR DESCRIPTION
Having a previous version of software-properties-common was causing the container to fail updating before trying to install solved the issue.
