### PR TITLE
Make Buildpack Work "at all" with Starphleet

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -7,7 +7,6 @@ sudo apt-get -y install --force-yes software-properties-common
 sudo add-apt-repository -y ppa:nginx/stable
 sudo apt-get update
 sudo apt-get -y install --force-yes nginx
-/etc/init.d/nginx stop
 
 BINDIR=$(dirname "$0")
 
@@ -18,3 +17,5 @@ fi
 if [[ ! -f "$1/mime.types" ]]; then
   cp "$BINDIR/../conf/mime.types" "$1/mime.types"
 fi
+
+sudo /etc/init.d/nginx stop || true

--- a/conf/nginx.conf.erb
+++ b/conf/nginx.conf.erb
@@ -14,5 +14,9 @@ http {
 		server_name  _;
 		root <%= ENV['HOME'] %>;
 		index index.html;
+    location = /diagnostic {
+      return 200;
+      access_log off;
+    }
 	}
 }


### PR DESCRIPTION
- Buildpack is run as non-root.  
- Installs NGINX.  
- Tries to stop NGINX with non-root which punts on error (set -e).
- BIND DIR confs don't work
- Broke the multi-buildpack.. err, build-pack
